### PR TITLE
那須塩原：帰属公園アイコン追加

### DIFF
--- a/attribution-park.svg
+++ b/attribution-park.svg
@@ -1,0 +1,24 @@
+<svg width="75" height="90" viewBox="0 0 75 90" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_d_844_2543)">
+<path d="M37.0463 74.3235L18.8971 52.7206L56.1029 52.7206L37.0463 74.3235Z" fill="#008FDF"/>
+<path d="M65 32.5C65 47.6878 52.6878 60 37.5 60C22.3122 60 10 47.6878 10 32.5C10 17.3122 22.3122 5 37.5 5C52.6878 5 65 17.3122 65 32.5Z" fill="white"/>
+<path d="M37.0463 74.3235L18.8971 52.7206L56.1029 52.7206L37.0463 74.3235Z" stroke="white" stroke-width="4" stroke-linejoin="round"/>
+<path d="M65 32.5C65 47.6878 52.6878 60 37.5 60C22.3122 60 10 47.6878 10 32.5C10 17.3122 22.3122 5 37.5 5C52.6878 5 65 17.3122 65 32.5Z" stroke="white" stroke-width="4" stroke-linejoin="round"/>
+</g>
+<path d="M37.0464 74.3237L18.8971 52.7208L56.103 52.7208L37.0464 74.3237Z" fill="#CCFF99"/>
+<path d="M37.5 8.09082C50.9808 8.09082 61.9092 19.0192 61.9092 32.5C61.9092 45.9808 50.9808 56.9092 37.5 56.9092C24.0192 56.9092 13.0908 45.9808 13.0908 32.5C13.0908 19.0192 24.0192 8.09082 37.5 8.09082Z" fill="#CCFF99" stroke="#CCFF99" stroke-width="6.18182"/>
+<ellipse cx="37.853" cy="33" rx="23" ry="23" fill="white"/>
+<path d="M50.4005 39.6363C51.1863 39.6363 51.3945 39.1628 50.8618 38.5852L42.4614 29.4603C41.9287 28.8827 42.1369 28.4092 42.9226 28.4092H47.6412C48.427 28.4092 48.6351 27.9357 48.1025 27.3581L38.9673 17.4332C38.4347 16.8556 37.5652 16.8556 37.0325 17.4332L27.8974 27.3581C27.3647 27.9357 27.5729 28.4092 28.3587 28.4092H33.0773C33.863 28.4092 34.0712 28.8827 33.5385 29.4603L25.1381 38.5852C24.6054 39.1628 24.8136 39.6363 25.5993 39.6363H33.4283C34.214 39.6363 34.8569 40.2792 34.8569 41.0649V47.5714C34.8569 48.3571 35.4998 49 36.2856 49H39.7143C40.5001 49 41.1429 48.3571 41.1429 47.5714V41.0649C41.1429 40.2792 41.7858 39.6363 42.5716 39.6363H50.4005Z" fill="#CCFF99"/>
+<defs>
+<filter id="filter0_d_844_2543" x="0" y="0" width="75" height="89.3237" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="5"/>
+<feGaussianBlur stdDeviation="4"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_844_2543"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_844_2543" result="shape"/>
+</filter>
+</defs>
+</svg>


### PR DESCRIPTION
Fixes #<issue_number>

## Summary
那須塩原さんから、帰属公園アイコンを R:204、G:255、B:153 の色で指定されたので追加

<!-- Briefly describe your changes -->

## Checklist (optional)

- [ ] Tests added/updated
- [ ] Docs updated
